### PR TITLE
Update namespace from WebApi.Models to Web.Api.Domains

### DIFF
--- a/src/GmlCore.Interfaces/Auth/IAuthServiceInfo.cs
+++ b/src/GmlCore.Interfaces/Auth/IAuthServiceInfo.cs
@@ -1,4 +1,4 @@
-using Gml.WebApi.Models.Enums.Auth;
+using Gml.Web.Api.Domains.System;
 
 namespace GmlCore.Interfaces.Auth
 {

--- a/src/GmlCore.Interfaces/GmlCore.Interfaces.csproj
+++ b/src/GmlCore.Interfaces/GmlCore.Interfaces.csproj
@@ -10,7 +10,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\..\..\Gml.WebApi.Models\Gml.WebApi.Models.csproj" />
+      <ProjectReference Include="..\..\..\Gml.Web.Api\src\Gml.Web.Api.Domains\Gml.Web.Api.Domains.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/GmlCore.Interfaces/Integrations/IServicesIntegrationProcedures.cs
+++ b/src/GmlCore.Interfaces/Integrations/IServicesIntegrationProcedures.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Gml.WebApi.Models.Enums.Auth;
+using Gml.Web.Api.Domains.System;
 using GmlCore.Interfaces.Auth;
 
 namespace GmlCore.Interfaces.Integrations

--- a/src/GmlCore.Interfaces/Launcher/IStartupOptions.cs
+++ b/src/GmlCore.Interfaces/Launcher/IStartupOptions.cs
@@ -1,4 +1,4 @@
-﻿using Gml.WebApi.Models.Enums.System;
+﻿using Gml.Web.Api.Domains.System;
 
 namespace GmlCore.Interfaces.Launcher
 {

--- a/src/GmlCore/Core/Integrations/ServicesIntegrationProcedures.cs
+++ b/src/GmlCore/Core/Integrations/ServicesIntegrationProcedures.cs
@@ -4,10 +4,9 @@ using System.Threading.Tasks;
 using Gml.Core.Constants;
 using Gml.Core.Services.Storage;
 using Gml.Models.Auth;
-using Gml.WebApi.Models.Enums.Auth;
+using Gml.Web.Api.Domains.System;
 using GmlCore.Interfaces.Auth;
 using GmlCore.Interfaces.Integrations;
-using NotImplementedException = System.NotImplementedException;
 
 namespace Gml.Core.Integrations
 {

--- a/src/GmlCore/Core/Launcher/StartupOptions.cs
+++ b/src/GmlCore/Core/Launcher/StartupOptions.cs
@@ -1,4 +1,4 @@
-using Gml.WebApi.Models.Enums.System;
+using Gml.Web.Api.Domains.System;
 using GmlCore.Interfaces.Launcher;
 
 namespace Gml.Core.Launcher

--- a/src/GmlCore/GmlCore.csproj
+++ b/src/GmlCore/GmlCore.csproj
@@ -19,7 +19,7 @@
     <ItemGroup>
       <ProjectReference Include="..\..\..\CmlLib.Core\CmlLib\CmlLib.csproj" />
       <ProjectReference Include="..\..\..\Gml.Common\Gml.Common\Gml.Common.csproj" />
-      <ProjectReference Include="..\..\..\Gml.WebApi.Models\Gml.WebApi.Models.csproj" />
+      <ProjectReference Include="..\..\..\Gml.Web.Api\src\Gml.Web.Api.Domains\Gml.Web.Api.Domains.csproj" />
       <ProjectReference Include="..\CmlLib.Core.Installer.Forge\CmlLib.Core.Installer.Forge\CmlLib.Core.Installer.Forge.csproj" />
       <ProjectReference Include="..\GmlCore.Interfaces\GmlCore.Interfaces.csproj" />
     </ItemGroup>

--- a/src/GmlCore/Models/Auth/AuthServiceInfo.cs
+++ b/src/GmlCore/Models/Auth/AuthServiceInfo.cs
@@ -1,4 +1,4 @@
-using Gml.WebApi.Models.Enums.Auth;
+using Gml.Web.Api.Domains.System;
 using GmlCore.Interfaces.Auth;
 
 namespace Gml.Models.Auth


### PR DESCRIPTION
The namespace in multiple files has been updated from 'Gml.WebApi.Models' to 'Gml.Web.Api.Domains'. This includes changes to import statements, as well as changes to project references in csproj files. The restructured namespace aims to provide better organization of the codebase.