### PR TITLE
Refactor path normalization in ProfileProcedures

### DIFF
--- a/src/GmlCore/Core/Helpers/Profiles/ProfileProcedures.cs
+++ b/src/GmlCore/Core/Helpers/Profiles/ProfileProcedures.cs
@@ -437,8 +437,7 @@ namespace Gml.Core.Helpers.Profiles
                                 .WithBucket(bucketName)
                                 .WithObject(file.Hash)
                                 .WithTagging(new Tagging(tags, true))
-                                .WithFileName(
-                                    Path.GetFullPath($"{_launcherInfo.InstallationDirectory}\\{file.Directory}"));
+                                .WithFileName(NormalizePath(_launcherInfo.InstallationDirectory, file.Directory));
 
                             await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
                         }
@@ -464,6 +463,21 @@ namespace Gml.Core.Helpers.Profiles
                 default:
                     throw new ArgumentOutOfRangeException();
             }
+        }
+
+        private string NormalizePath(string directory, string fileDirectory)
+        {
+            directory = directory
+                .Replace('\\', Path.DirectorySeparatorChar)
+                .Replace('/', Path.DirectorySeparatorChar)
+                .TrimStart(Path.DirectorySeparatorChar);
+
+            fileDirectory = fileDirectory
+                .Replace('\\', Path.DirectorySeparatorChar)
+                .Replace('/', Path.DirectorySeparatorChar)
+                .TrimStart(Path.DirectorySeparatorChar);
+
+            return Path.Combine(directory, fileDirectory);
         }
 
         public async Task AddFileToWhiteList(IGameProfile profile, IFileInfo file)

--- a/src/GmlCore/Core/Services/Storage/SqliteStorageService.cs
+++ b/src/GmlCore/Core/Services/Storage/SqliteStorageService.cs
@@ -14,7 +14,6 @@ namespace Gml.Core.Services.Storage
         private readonly string _databasePath;
         private readonly IGmlSettings _settings;
 
-
         public SqliteStorageService(IGmlSettings settings)
         {
             _settings = settings;


### PR DESCRIPTION
Extracted the path normalization logic into a separate method named NormalizePath in ProfileProcedures class. This method improves path handling by making it OS-agnostic, replacing specific directory separator characters by the one used by the current OS. This refactoring also makes the code cleaner and easier to understand.