### PR TITLE
Add DiscordRpc integration to the ServicesIntegrationProcedures

### DIFF
--- a/src/GmlCore.Interfaces/Integrations/IDiscordRpcClient.cs
+++ b/src/GmlCore.Interfaces/Integrations/IDiscordRpcClient.cs
@@ -1,0 +1,11 @@
+namespace GmlCore.Interfaces.Integrations;
+
+public interface IDiscordRpcClient
+{
+    public string ClientId { get; set; }
+    public string Details { get; set; }
+    public string LargeImageKey { get; set; }
+    public string LargeImageText { get; set; }
+    public string SmallImageKey { get; set; }
+    public string SmallImageText { get; set; }
+}

--- a/src/GmlCore.Interfaces/Integrations/IServicesIntegrationProcedures.cs
+++ b/src/GmlCore.Interfaces/Integrations/IServicesIntegrationProcedures.cs
@@ -19,5 +19,7 @@ namespace GmlCore.Interfaces.Integrations
         Task SetCloakServiceAsync(string url);
         Task<string?> GetSentryService();
         Task SetSentryService(string url);
+        Task UpdateDiscordRpc(IDiscordRpcClient client);
+        Task<IDiscordRpcClient?> GetDiscordRpc();
     }
 }

--- a/src/GmlCore/Core/Constants/StorageConstants.cs
+++ b/src/GmlCore/Core/Constants/StorageConstants.cs
@@ -8,6 +8,7 @@ namespace Gml.Core.Constants
         public const string SkinUrl = "SkinUrl";
         public const string CloakUrl = "CloakUrl";
         public const string SentrySdnUrl = "SentrySdnUrl";
+        public const string DiscordRpcClient = "DiscordRpcClient";
         public const string Settings = "Settings";
     }
 }

--- a/src/GmlCore/Core/Integrations/ServicesIntegrationProcedures.cs
+++ b/src/GmlCore/Core/Integrations/ServicesIntegrationProcedures.cs
@@ -2,9 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using CmlLib.Core.Installer.FabricMC;
 using Gml.Core.Constants;
 using Gml.Core.Services.Storage;
 using Gml.Models.Auth;
+using Gml.Web.Api.Domains.Integrations;
 using Gml.Web.Api.Domains.System;
 using GmlCore.Interfaces.Auth;
 using GmlCore.Interfaces.Enums;
@@ -98,6 +100,18 @@ namespace Gml.Core.Integrations
         public Task SetSentryService(string url)
         {
             return _storage.SetAsync(StorageConstants.SentrySdnUrl, url);
+        }
+
+        public Task UpdateDiscordRpc(IDiscordRpcClient client)
+        {
+            return _storage.SetAsync(StorageConstants.DiscordRpcClient, client);
+        }
+
+        public async Task<IDiscordRpcClient?> GetDiscordRpc()
+        {
+            return await _storage
+                .GetAsync<DiscordRpcClient>(StorageConstants.DiscordRpcClient)
+                .ConfigureAwait(false);
         }
     }
 }


### PR DESCRIPTION
This commit introduces a new feature, the integration of a Discord RPC client to the ServicesIntegrationProcedures. It involves adding methods for setting and getting a Discord RPC client, a constant for storing a reference to the client, and designing a new interface describing the properties of a Discord RPC client.