### PR TITLE
Remove start trimming for directory paths

### DIFF
--- a/src/GmlCore/Core/Helpers/Profiles/ProfileProcedures.cs
+++ b/src/GmlCore/Core/Helpers/Profiles/ProfileProcedures.cs
@@ -477,13 +477,13 @@ namespace Gml.Core.Helpers.Profiles
         {
             directory = directory
                 .Replace('\\', Path.DirectorySeparatorChar)
-                .Replace('/', Path.DirectorySeparatorChar)
-                .TrimStart(Path.DirectorySeparatorChar);
+                .Replace('/', Path.DirectorySeparatorChar);
+                // .TrimStart(Path.DirectorySeparatorChar);
 
             fileDirectory = fileDirectory
                 .Replace('\\', Path.DirectorySeparatorChar)
-                .Replace('/', Path.DirectorySeparatorChar)
-                .TrimStart(Path.DirectorySeparatorChar);
+                .Replace('/', Path.DirectorySeparatorChar);
+                // .TrimStart(Path.DirectorySeparatorChar);
 
             return Path.Combine(directory, fileDirectory);
         }


### PR DESCRIPTION
The trimming at the start of directory and file directory paths, in ProfileProcedures.cs, has been removed. This change was made to maintain any leading directory separator characters, which were previously trimmed off.