### PR TITLE
Enable trim start for file directory paths

### DIFF
--- a/src/GmlCore/Core/Helpers/Profiles/ProfileProcedures.cs
+++ b/src/GmlCore/Core/Helpers/Profiles/ProfileProcedures.cs
@@ -482,8 +482,8 @@ namespace Gml.Core.Helpers.Profiles
 
             fileDirectory = fileDirectory
                 .Replace('\\', Path.DirectorySeparatorChar)
-                .Replace('/', Path.DirectorySeparatorChar);
-                // .TrimStart(Path.DirectorySeparatorChar);
+                .Replace('/', Path.DirectorySeparatorChar)
+                .TrimStart(Path.DirectorySeparatorChar);
 
             return Path.Combine(directory, fileDirectory);
         }


### PR DESCRIPTION
The change removes the comment and enables the trim start function for file directory paths in the ProfileProcedures class. This ensures that file paths are always correctly formatted, removing any unnecessary directory separator character at the beginning.