### PR TITLE
Add EasyCabinet as new auth type

### DIFF
--- a/src/GmlCore.Interfaces/Enums/AuthType.cs
+++ b/src/GmlCore.Interfaces/Enums/AuthType.cs
@@ -5,5 +5,6 @@ public enum AuthType
     Undefined = 0,
     DataLifeEngine = 1,
     Any = 2,
-    Azuriom = 3
+    Azuriom = 3,
+    EasyCabinet = 4,
 }

--- a/src/GmlCore/Core/Integrations/ServicesIntegrationProcedures.cs
+++ b/src/GmlCore/Core/Integrations/ServicesIntegrationProcedures.cs
@@ -36,7 +36,8 @@ namespace Gml.Core.Integrations
                 new AuthServiceInfo("Undefined", AuthType.Undefined),
                 new AuthServiceInfo("Any", AuthType.Any),
                 new AuthServiceInfo("DataLifeEngine", AuthType.DataLifeEngine),
-                new AuthServiceInfo("Azuriom", AuthType.Azuriom)
+                new AuthServiceInfo("Azuriom", AuthType.Azuriom),
+                new AuthServiceInfo("EasyCabinet", AuthType.EasyCabinet)
             }.AsEnumerable());
         }
 


### PR DESCRIPTION
A new auth type, 'EasyCabinet', has been added to the auth type enums. It is also added to the services integration procedure file to provide information about this type.