### PR TITLE
Add server removal functionality to ProfileServersProcedures

### DIFF
--- a/src/Gml.Core.Interfaces/Procedures/IProfileServersProcedures.cs
+++ b/src/Gml.Core.Interfaces/Procedures/IProfileServersProcedures.cs
@@ -8,4 +8,5 @@ public interface IProfileServersProcedures
 {
     Task<IProfileServer> AddMinecraftServer(IGameProfile profileprofile, string serverName, string address, int port);
     Task UpdateServerState(IProfileServer minecraftServer);
+    Task RemoveServer(IGameProfile profile, string serverName);
 }

--- a/src/Gml.Core/Core/Helpers/Profiles/ProfileServersProcedures.cs
+++ b/src/Gml.Core/Core/Helpers/Profiles/ProfileServersProcedures.cs
@@ -68,4 +68,26 @@ public partial class ProfileProcedures : IProfileServersProcedures
             minecraftServer.IsOnline = status?.MaximumPlayers is not null;
         }
     }
+
+    public async Task RemoveServer(IGameProfile profile, string serverName)
+    {
+        if (profile == null)
+        {
+            throw new ArgumentNullException(nameof(profile), "Profile cannot be null.");
+        }
+
+        if (string.IsNullOrEmpty(serverName))
+        {
+            throw new ArgumentException("Server name cannot be null or empty.", nameof(serverName));
+        }
+
+        var server = profile.Servers.FirstOrDefault(c => c.Name == serverName);
+
+        if (server is not null)
+        {
+            profile.Servers.Remove(server);
+        }
+
+        await SaveProfiles();
+    }
 }


### PR DESCRIPTION
Added a RemoveServer method to the IProfileServersProcedures.cs interface and implemented the logic for it in ProfileServersProcedures.cs. The method will remove a server from a given profile's server list by the server name. It also contains input validation.