### PR TITLE
Updated AuthUserHistory constructor accessibility

### DIFF
--- a/src/Gml.Core/Core/User/AuthUserHistory.cs
+++ b/src/Gml.Core/Core/User/AuthUserHistory.cs
@@ -4,7 +4,7 @@ namespace Gml.Core.User
 {
     public class AuthUserHistory
     {
-        internal AuthUserHistory()
+        public AuthUserHistory()
         {
         }
 


### PR DESCRIPTION
The previous constructor of the AuthUserHistory class was marked as internal. Now, it has been made publicly accessible to enable objects' instantiations from different assemblies.