### PR TITLE
Add isEnabled attribute to GameProfile model

### DIFF
--- a/src/Gml.Core.Interfaces/Launcher/IGameProfile.cs
+++ b/src/Gml.Core.Interfaces/Launcher/IGameProfile.cs
@@ -19,6 +19,7 @@ namespace GmlCore.Interfaces.Launcher
         [JsonIgnore] IGameDownloaderProcedures GameLoader { get; set; }
 
         string Name { get; set; }
+        bool IsEnabled { get; set; }
         string GameVersion { get; set; }
         string LaunchVersion { get; set; }
         GameLoader Loader { get; }

--- a/src/Gml.Core.Interfaces/Procedures/IProfileProcedures.cs
+++ b/src/Gml.Core.Interfaces/Procedures/IProfileProcedures.cs
@@ -41,7 +41,7 @@ namespace GmlCore.Interfaces.Procedures
         Task AddFileToWhiteList(IGameProfile profile, IFileInfo file);
         Task RemoveFileFromWhiteList(IGameProfile profile, IFileInfo file);
         Task UpdateProfile(IGameProfile profile, string newProfileName, Stream? icon, Stream? backgroundImage,
-            string updateDtoDescription);
+            string updateDtoDescription, bool isEnabled);
         Task<string[]> InstallAuthLib(IGameProfile profile);
         Task<IGameProfileInfo?> GetCacheProfile(IGameProfile baseProfile);
         Task SetCacheProfile(IGameProfileInfo profile);

--- a/src/Gml.Core/Core/Helpers/Profiles/ProfileProcedures.cs
+++ b/src/Gml.Core/Core/Helpers/Profiles/ProfileProcedures.cs
@@ -97,6 +97,7 @@ namespace Gml.Core.Helpers.Profiles
             {
                 ProfileProcedures = this,
                 ServerProcedures = this,
+                IsEnabled = true,
                 CreateDate = DateTimeOffset.Now,
                 Description = description,
                 IconBase64 = icon
@@ -507,7 +508,8 @@ namespace Gml.Core.Helpers.Profiles
             string newProfileName,
             Stream? icon,
             Stream? backgroundImage,
-            string updateDtoDescription)
+            string updateDtoDescription,
+            bool isEnabled)
         {
             var directory =
                 new DirectoryInfo(Path.Combine(_launcherInfo.InstallationDirectory, "clients", profile.Name));
@@ -527,7 +529,7 @@ namespace Gml.Core.Helpers.Profiles
                 ? profile.BackgroundImageKey
                 : await _gmlManager.Files.LoadFile(backgroundImage);
 
-            await UpdateProfile(profile, newProfileName, iconBase64, backgroundKey, updateDtoDescription, needRenameFolder, directory, newDirectory);
+            await UpdateProfile(profile, newProfileName, iconBase64, backgroundKey, updateDtoDescription, needRenameFolder, directory, newDirectory, isEnabled);
         }
 
         private async Task<string> ConvertStreamToBase64Async(Stream stream)
@@ -542,12 +544,14 @@ namespace Gml.Core.Helpers.Profiles
 
         private async Task UpdateProfile(IGameProfile profile, string newProfileName, string newIcon,
             string backgroundImageKey,
-            string newDescription, bool needRenameFolder, DirectoryInfo directory, DirectoryInfo newDirectory)
+            string newDescription, bool needRenameFolder, DirectoryInfo directory, DirectoryInfo newDirectory,
+            bool isEnabled)
         {
             profile.Name = newProfileName;
             profile.IconBase64 = newIcon;
             profile.BackgroundImageKey = backgroundImageKey;
             profile.Description = newDescription;
+            profile.IsEnabled = isEnabled;
 
             profile.GameLoader = new GameDownloaderProcedures(_launcherInfo, _storageService, profile);
 

--- a/src/Gml.Core/Models/BaseProfile.cs
+++ b/src/Gml.Core/Models/BaseProfile.cs
@@ -41,6 +41,7 @@ namespace Gml.Models
         [JsonIgnore] public IGameDownloaderProcedures GameLoader { get; set; }
 
         public string Name { get; set; }
+        public bool IsEnabled { get; set; }
         public string GameVersion { get; set; }
         public string LaunchVersion { get; set; }
         public GameLoader Loader { get; set; }


### PR DESCRIPTION
The commit introduces a new attribute, "isEnabled", to the GameProfile model, which is used to determine the current state of the game profile. The methods Add() and UpdateProfile() in the ProfileProcedures class were updated to include this new attribute when creating or updating a game profile.