### PR TITLE
Add JVM arguments to game profiles

### DIFF
--- a/src/Gml.Core.Interfaces/Launcher/IGameProfile.cs
+++ b/src/Gml.Core.Interfaces/Launcher/IGameProfile.cs
@@ -30,6 +30,7 @@ namespace GmlCore.Interfaces.Launcher
         List<IFileInfo>? FileWhiteList { get; set; }
         List<IProfileServer> Servers { get; set; }
         DateTimeOffset CreateDate { get; set; }
+        string JvmArguments { get; set; }
 
         Task<bool> ValidateProfile();
         Task<bool> CheckIsFullLoaded(IStartupOptions startupOptions);

--- a/src/Gml.Core.Interfaces/Procedures/IProfileProcedures.cs
+++ b/src/Gml.Core.Interfaces/Procedures/IProfileProcedures.cs
@@ -41,7 +41,8 @@ namespace GmlCore.Interfaces.Procedures
         Task AddFileToWhiteList(IGameProfile profile, IFileInfo file);
         Task RemoveFileFromWhiteList(IGameProfile profile, IFileInfo file);
         Task UpdateProfile(IGameProfile profile, string newProfileName, Stream? icon, Stream? backgroundImage,
-            string updateDtoDescription, bool isEnabled);
+            string updateDtoDescription, bool isEnabled,
+            string jvmArguments);
         Task<string[]> InstallAuthLib(IGameProfile profile);
         Task<IGameProfileInfo?> GetCacheProfile(IGameProfile baseProfile);
         Task SetCacheProfile(IGameProfileInfo profile);

--- a/src/Gml.Core/Core/Launcher/GameProfileInfo.cs
+++ b/src/Gml.Core/Core/Launcher/GameProfileInfo.cs
@@ -16,5 +16,6 @@ namespace Gml.Core.Launcher
         public string MinecraftVersion { get; set; }
         public string ClientVersion { get; set; }
         public string Arguments { get; set; }
+        public string JvmArguments { get; set; }
     }
 }

--- a/src/Gml.Core/Models/BaseProfile.cs
+++ b/src/Gml.Core/Models/BaseProfile.cs
@@ -50,6 +50,7 @@ namespace Gml.Models
         public string BackgroundImageKey { get; set; }
         public string Description { get; set; }
 
+        public string JvmArguments { get; set; }
         [JsonConverter(typeof(LocalFileInfoConverter))]
         public List<IFileInfo>? FileWhiteList { get; set; }
 


### PR DESCRIPTION
Added a new property for JVM arguments to the game profile model, reflected this change in involved methods and classes. Now it is possible to pass JVM arguments to these game profiles for further use.